### PR TITLE
Merge upstream: Retrieve the associated NSView more reliably

### DIFF
--- a/src/macpreferenceswindow.mm
+++ b/src/macpreferenceswindow.mm
@@ -28,6 +28,7 @@
  */
 
 #include "macpreferenceswindow.h"
+#include "macwindow.h"
 
 #include <QVBoxLayout>
 #include <QToolBar>
@@ -205,7 +206,10 @@ void MacPreferencesWindowPrivate::displayPanel(int panelIndex)
     bool isUpdatingTheAlreadyVisiblePanel = panelIndex == currentPanelIndex;
 
 
-    NSView *view = reinterpret_cast<NSView *>(q->effectiveWinId());
+    NSView *view = MacWindow::nsview(q);
+    if (!view) {
+        return;
+    }
     NSRect frame = view.window.frame;
 
     static const int TitlebarHeight = 22;

--- a/src/macwindow.h
+++ b/src/macwindow.h
@@ -30,9 +30,18 @@
 #ifndef MAC_WINDOW_H
 #define MAC_WINDOW_H
 
+#ifdef __OBJC__
+@class NSView;
+#else
+class NSView;
+#endif
+
 class QWidget;
 class MacWindow {
 public:
+    // Retrieve the Cocoa NSView associated with a QWidget
+    static NSView *nsview(QWidget *w);
+
     static void bringToFront(QWidget *w);
 };
 

--- a/src/macwindow.mm
+++ b/src/macwindow.mm
@@ -32,22 +32,35 @@
 #include <QtMacExtras>
 #include <QDebug>
 #include <QWidget>
+#include <QGuiApplication>
+#include <qpa/qplatformnativeinterface.h> // private Qt header!
 
 #import <Cocoa/Cocoa.h>
 #import <Availability.h>
 
-// viel hilft viel ;-)
+NSView *MacWindow::nsview(QWidget *w)
+{
+    // Code similar to getEmbeddableView() in QMacNativeWidget
+    w->winId();
+    w->windowHandle()->create();
+    QPlatformNativeInterface *platformNativeInterface = QGuiApplication::platformNativeInterface();
+    return (NSView *)platformNativeInterface->nativeResourceForWindow("nsview", w->windowHandle());
+}
+
 void MacWindow::bringToFront(QWidget *w) {
     Q_UNUSED(w);
 
     NSApplication *nsapp = [NSApplication sharedApplication];
     [nsapp activateIgnoringOtherApps:YES];
 
-    NSView *nsview = (NSView*)w->winId();
-    if (![nsview isKindOfClass:[NSView class]]) {
+    NSView *view = nsview(w);
+    if (!view) {
         return;
     }
-    NSWindow *nswin = [nsview window];
+    if (![view isKindOfClass:[NSView class]]) {
+        return;
+    }
+    NSWindow *nswin = [view window];
     if ([nswin isKindOfClass:[NSWindow class]]) {
         [nswin makeKeyAndOrderFront:nswin];
         [nswin setOrderedIndex:0];


### PR DESCRIPTION
With Qt 5.12.5 this crash also applies to the Nextcloud Desktop Client on macOS.

The upstream commit fixes it.

Also there is a change needed to `src/gui/CMakeLists.txt`, to include a Qt-private header file,
please see PR: https://github.com/nextcloud/desktop/pull/1520

For reference see: https://github.com/owncloud/client/commit/f0ef50031808245fedf364a423c54a2149e736a4

_Original commit message:_

> See https://github.com/owncloud/client/issues/6930 for a crash report
> pointing to an invalid pointer being used when using (NSView*)winId.
> 
> The updated code unfortunately uses private Qt headers but retrieves
> the NSView in the same way that QMacNativeWidget does, which tests
> indicate is more robust.
> 
> Thanks to @yan12125 for testing.