### PR TITLE
Bugfix for Qt 5.12.5 - Redraw the ToolBar

### DIFF
--- a/src/macpreferenceswindow.mm
+++ b/src/macpreferenceswindow.mm
@@ -292,6 +292,12 @@ bool MacPreferencesWindow::event(QEvent *event)
     switch (event->type()) {
     case QEvent::Show:
         d->displayPanel(d->currentPanelIndex);
+
+        // BUGFIX for Qt 5.12.5 - Redraw the ToolBar:
+        //        After hiding and re-opening the settings window,
+        //        the ToolBar background was transparent.
+        setUnifiedTitleAndToolBarOnMac(true);
+
         break;
     default:
         break;


### PR DESCRIPTION
After hiding and re-opening the settings window, the ToolBar background was transparent.